### PR TITLE
feat(pkgbuild): update to 0.12.55

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: AstroSteveO <stevengmjr at gmail dot com>
 
 pkgname=claude-desktop-native
-pkgver=0.12.49
+pkgver=0.12.55
 pkgrel=1
 pkgdesc="Unofficial Claude Desktop for Linux"
 arch=('x86_64')
@@ -12,7 +12,7 @@ makedepends=('p7zip' 'npm' 'nodejs' 'rust' 'cargo' 'imagemagick' 'icoutils' 'tar
 optdepends=('docker: for running MCP servers')
 source=("Claude-Setup-x64.exe::https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe"
   "patchy-cnb-1.0.0.tar.gz::https://github.com/claude-desktop-native/patchy-cnb/archive/refs/tags/v1.0.0.tar.gz")
-sha256sums=('b900c76b1976aa5b9f2f128df3770e6dac2d1ba0fcc7ff87fa10e0625bfe0ef7'
+sha256sums=('8669efacd2b08f6671d9ed98a550681104490b86c92e3241148afa362a4d2938'
   'c5bba36cf5d076f61dec3ade072eb61a62818fa2f1584e88cbe8ef775776ca83')
 
 prepare() {


### PR DESCRIPTION
Update Claude Desktop version from 0.12.49 to 0.12.55 and fix SHA256 checksum to match the current upstream installer.