### PR TITLE
feat: Use versioned exe files in PKGBUILD

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = claude-desktop-native
 	pkgdesc = Unofficial Claude Desktop for Linux
-	pkgver = 0.8.1
-	pkgrel = 1
+	pkgver = 0.13.19
+	pkgrel = 2
 	url = https://github.com/claude-desktop-native/claude-desktop-native.git
 	arch = x86_64
 	license = MIT
@@ -16,9 +16,9 @@ pkgbase = claude-desktop-native
 	makedepends = tar
 	depends = electron
 	optdepends = docker: for running MCP servers
-	source = Claude-Setup-x64.exe::https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe
-	source = patchy-cnb-1.0.0.tar.gz::https://github.com/claude-desktop-native/patchy-cnb/archive/refs/tags/v1.0.0.tar.gz
-	sha256sums = f63b5584e409ce95b89c57af7d3a4d9effcbff11ab80a2bd9270192051318ab0
-	sha256sums = c5bba36cf5d076f61dec3ade072eb61a62818fa2f1584e88cbe8ef775776ca83
+	source = Claude-Setup-x64-0.13.19-2.exe::https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe
+	source = patchy-cnb::git+https://github.com/k3d3/claude-desktop-linux-flake.git
+	sha256sums = 0f00a04d20692b6f2c4420540416ad3ec681650fb2c8bac96c0ae24a47f57fc1
+	sha256sums = SKIP
 
 pkgname = claude-desktop-native

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/src/
+/pkg/
+/patchy-cnb/
+/claude-desktop-native*pkg.tar*
+/Claude-Setup-x64*exe

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=claude-desktop-native
 pkgver=0.13.19
-pkgrel=1
+pkgrel=2
 pkgdesc="Unofficial Claude Desktop for Linux"
 arch=('x86_64')
 url="https://github.com/claude-desktop-native/claude-desktop-native.git"
@@ -10,7 +10,7 @@ license=('MIT' 'Apache')
 depends=('electron')
 makedepends=('p7zip' 'npm' 'nodejs' 'rust' 'cargo' 'imagemagick' 'icoutils' 'tar')
 optdepends=('docker: for running MCP servers')
-source=("Claude-Setup-x64.exe::https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe"
+source=("Claude-Setup-x64-${pkgver}-${pkgrel}.exe::https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe"
   "patchy-cnb::git+https://github.com/k3d3/claude-desktop-linux-flake.git")
 sha256sums=('0f00a04d20692b6f2c4420540416ad3ec681650fb2c8bac96c0ae24a47f57fc1'
   'SKIP')


### PR DESCRIPTION
Otherwise doing a git pull on an existing clone and running makepkg gives a checksum error.

This avoids that problem by making the exe files versioned.